### PR TITLE
Fix completing lifecycle actions

### DIFF
--- a/lib/ex_aws/ex_aws_auto_scaling.ex
+++ b/lib/ex_aws/ex_aws_auto_scaling.ex
@@ -1527,7 +1527,7 @@ defmodule ExAws.AutoScaling do
       {:lifecycle_hook_name, lifecycle_hook_name},
       {:lifecycle_action_result, lifecycle_action_result} | opts
     ]
-    |> build_request(:complete_life_cycle_action)
+    |> build_request(:complete_lifecycle_action)
   end
 
   @doc """


### PR DESCRIPTION
Before the action was exanding to `CompleteLifeCycleAction`, which does not exist. `CompleteLifecycleAction` does though. Now folks can complete lifecycle actions, hurray!